### PR TITLE
Add pam authentication

### DIFF
--- a/examples/ssl_list_dir/account.yml
+++ b/examples/ssl_list_dir/account.yml
@@ -1,0 +1,16 @@
+host:
+  hostname: "ssldata.cyverse.org"
+  port: 1247
+user:
+  username: ""
+  password: ""
+  zone: "iplant"
+auth_scheme: "pam"
+cs_negotiation: true
+cs_negotiation_policy: "CS_NEG_REQUIRE"
+ssl:
+  ca_cert_file: "/etc/ssl/certs/ca-bundle.crt"
+  key_size: 32
+  algorithm: "AES-256-CBC"
+  salt_size: 8
+  hash_rounds: 16

--- a/examples/ssl_list_dir/list_dir.go
+++ b/examples/ssl_list_dir/list_dir.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/cyverse/go-irodsclient/fs"
+	"github.com/cyverse/go-irodsclient/irods/types"
+	"github.com/cyverse/go-irodsclient/irods/util"
+)
+
+func main() {
+	util.SetLogLevel(9)
+
+	// Parse cli parameters
+	flag.Parse()
+	args := flag.Args()
+
+	if len(args) != 1 {
+		fmt.Fprintf(os.Stderr, "Give an iRODS path!\n")
+		os.Exit(1)
+	}
+
+	inputPath := args[0]
+
+	// Read account configuration from YAML file
+	yaml, err := ioutil.ReadFile("account.yml")
+	if err != nil {
+		util.LogErrorf("err - %v", err)
+		panic(err)
+	}
+
+	account, err := types.CreateIRODSAccountFromYAML(yaml)
+	if err != nil {
+		util.LogErrorf("err - %v", err)
+		panic(err)
+	}
+
+	util.LogDebugf("Account : %v", account.MaskSensitiveData())
+
+	// Create a file system
+	appName := "list_dir"
+	filesystem := fs.NewFileSystemWithDefault(account, appName)
+	defer filesystem.Release()
+
+	entries, err := filesystem.List(inputPath)
+	if err != nil {
+		util.LogErrorf("err - %v", err)
+		panic(err)
+	}
+
+	if len(entries) == 0 {
+		fmt.Printf("Found no entries in the directory - %s\n", inputPath)
+	} else {
+		fmt.Printf("DIR: %s\n", inputPath)
+		for _, entry := range entries {
+			if entry.Type == fs.FSFileEntry {
+				fmt.Printf("> FILE:\t%s\t%d\n", entry.Path, entry.Size)
+			} else {
+				// dir
+				fmt.Printf("> DIRECTORY:\t%s\n", entry.Path)
+			}
+
+		}
+	}
+}

--- a/irods/message/auth_pam_request.go
+++ b/irods/message/auth_pam_request.go
@@ -1,0 +1,62 @@
+package message
+
+import (
+	"encoding/xml"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+)
+
+// IRODSMessagePamAuthRequest stores auth response
+type IRODSMessagePamAuthRequest struct {
+	XMLName  xml.Name `xml:"pamAuthRequestInp_PI"`
+	Username string   `xml:"pamUser"`
+	Password string   `xml:"pamPassword"`
+	TTL      int      `xml:"timeToLive"`
+}
+
+// NewIRODSMessagePamAuthRequest creates a IRODSMessagePamAuthRequest message
+func NewIRODSMessagePamAuthRequest(username, password string, ttl int) *IRODSMessagePamAuthRequest {
+	return &IRODSMessagePamAuthRequest{
+		Username: username,
+		Password: password,
+		TTL:      ttl,
+	}
+}
+
+// GetBytes returns byte array
+func (msg *IRODSMessagePamAuthRequest) GetBytes() ([]byte, error) {
+	xmlBytes, err := xml.Marshal(msg)
+	return xmlBytes, err
+}
+
+// FromBytes returns struct from bytes
+func (msg *IRODSMessagePamAuthRequest) FromBytes(bytes []byte) error {
+	err := xml.Unmarshal(bytes, msg)
+	return err
+}
+
+// GetMessage builds a message
+func (msg *IRODSMessagePamAuthRequest) GetMessage() (*IRODSMessage, error) {
+	bytes, err := msg.GetBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	msgBody := IRODSMessageBody{
+		Type:    RODS_MESSAGE_API_REQ_TYPE,
+		Message: bytes,
+		Error:   nil,
+		Bs:      nil,
+		IntInfo: int32(common.PAM_AUTH_REQUEST_AN),
+	}
+
+	msgHeader, err := msgBody.BuildHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	return &IRODSMessage{
+		Header: msgHeader,
+		Body:   &msgBody,
+	}, nil
+}

--- a/irods/message/auth_pam_response.go
+++ b/irods/message/auth_pam_response.go
@@ -1,0 +1,34 @@
+package message
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// IRODSMessagePamAuthResponse stores auth challenge
+type IRODSMessagePamAuthResponse struct {
+	XMLName           xml.Name `xml:"pamAuthRequestOut_PI"`
+	GeneratedPassword string   `xml:"irodsPamPassword"`
+}
+
+// GetBytes returns byte array
+func (msg *IRODSMessagePamAuthResponse) GetBytes() ([]byte, error) {
+	xmlBytes, err := xml.Marshal(msg)
+	return xmlBytes, err
+}
+
+// FromBytes returns struct from bytes
+func (msg *IRODSMessagePamAuthResponse) FromBytes(bytes []byte) error {
+	err := xml.Unmarshal(bytes, msg)
+	return err
+}
+
+// FromMessage returns struct from IRODSMessage
+func (msg *IRODSMessagePamAuthResponse) FromMessage(msgIn *IRODSMessage) error {
+	if msgIn.Body == nil {
+		return fmt.Errorf("Cannot create a struct from an empty body")
+	}
+
+	err := msg.FromBytes(msgIn.Body.Message)
+	return err
+}

--- a/irods/types/account.go
+++ b/irods/types/account.go
@@ -19,6 +19,7 @@ type IRODSAccount struct {
 	ProxyZone               string
 	ServerDN                string
 	Password                string
+	PamTTL                  int
 	SSLConfiguration        *IRODSSSLConfig
 }
 

--- a/irods/types/cs_negotiation.go
+++ b/irods/types/cs_negotiation.go
@@ -69,9 +69,9 @@ func GetCSNegotiationPolicy(policy string) (CSNegotiationPolicy, error) {
 func PerformCSNegotiation(clientRequest CSNegotiationRequire, serverRequest CSNegotiationRequire) (CSNegotiationPolicy, int) {
 	if serverRequest == CSNegotiationDontCare {
 		if clientRequest == CSNegotiationDontCare {
-			return CSNegotiationUseSSL, 1
+			return CSNegotiationUseTCP, 1
 		}
-		return CSNegotiationUseTCP, 1
+		return CSNegotiationUseSSL, 1
 	}
 
 	if clientRequest == serverRequest {


### PR DESCRIPTION
Hi, I'm very interested in this project as it opens the door for lots of integrations at our side. As we use pam authentication, I've added an implementation of the loginPAM function.

I did change the function loginNative to accept a password, as pam authentication apparently works by giving a temporary password to the client, which then can be used by a native login attempt, as seen here: 
https://github.com/stefan-wolfsheimer/irods_client_icommands/blob/master/src/iinit.cpp#L286-L314

Note that I just require SSL, and do not attempt to set it up when doing the loginPam function as the cpp-version seems to do.