### PR TITLE
Add metadata modification messages

### DIFF
--- a/irods/fs/collection.go
+++ b/irods/fs/collection.go
@@ -476,3 +476,78 @@ func MoveCollection(conn *connection.IRODSConnection, srcPath string, destPath s
 	err = response.CheckError()
 	return err
 }
+
+// AddCollectionMeta sets metadata of a data object for the path to the given key values.
+// metadata.AVUID is ignored
+func AddCollectionMeta(conn *connection.IRODSConnection, path string, metadata *types.IRODSMeta) error {
+	if conn == nil || !conn.IsConnected() {
+		return fmt.Errorf("connection is nil or disconnected")
+	}
+
+	request := message.NewIRODSMessageAddMetadataRequest(types.IRODSCollectionMetaItemType, path, metadata)
+	requestMessage, err := request.GetMessage()
+	if err != nil {
+		return fmt.Errorf("Could not make a metadata modification request message - %v", err)
+	}
+
+	err = conn.SendMessage(requestMessage)
+	if err != nil {
+		return fmt.Errorf("Could not send a metadata modification request message - %v", err)
+	}
+
+	// Server responds with results
+	responseMessage, err := conn.ReadMessage()
+	if err != nil {
+		return fmt.Errorf("Could not receive a metadata modification response message - %v", err)
+	}
+
+	response := message.IRODSMessageModMetaResponse{}
+	err = response.FromMessage(responseMessage)
+	if err != nil {
+		return fmt.Errorf("Could not receive a metadata modification response message - %v", err)
+	}
+
+	err = response.CheckError()
+	return err
+}
+
+// DeleteCollectionMeta sets metadata of a data object for the path to the given key values.
+// The metadata AVU is selected on basis of AVUID if it is supplied, otherwise on basis of Name, Value and Units.
+func DeleteCollectionMeta(conn *connection.IRODSConnection, path string, metadata *types.IRODSMeta) error {
+	if conn == nil || !conn.IsConnected() {
+		return fmt.Errorf("connection is nil or disconnected")
+	}
+
+	var request *message.IRODSMessageModMetaRequest
+
+	if metadata.AVUID != 0 {
+		request = message.NewIRODSMessageRemoveMetadataByIDRequest(types.IRODSCollectionMetaItemType, path, metadata.AVUID)
+	} else {
+		request = message.NewIRODSMessageRemoveMetadataRequest(types.IRODSCollectionMetaItemType, path, metadata)
+	}
+
+	requestMessage, err := request.GetMessage()
+	if err != nil {
+		return fmt.Errorf("Could not make a metadata modification request message - %v", err)
+	}
+
+	err = conn.SendMessage(requestMessage)
+	if err != nil {
+		return fmt.Errorf("Could not send a metadata modification request message - %v", err)
+	}
+
+	// Server responds with results
+	responseMessage, err := conn.ReadMessage()
+	if err != nil {
+		return fmt.Errorf("Could not receive a metadata modification response message - %v", err)
+	}
+
+	response := message.IRODSMessageModMetaResponse{}
+	err = response.FromMessage(responseMessage)
+	if err != nil {
+		return fmt.Errorf("Could not receive a metadata modification response message - %v", err)
+	}
+
+	err = response.CheckError()
+	return err
+}

--- a/irods/message/modmeta_request.go
+++ b/irods/message/modmeta_request.go
@@ -1,0 +1,137 @@
+package message
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+	"github.com/cyverse/go-irodsclient/irods/types"
+)
+
+// IRODSMessageModMetaRequest stores alter metadata request
+type IRODSMessageModMetaRequest struct {
+	XMLName      xml.Name `xml:"ModAVUMetadataInp_PI"`
+	Operation    string   `xml:"arg0"` // add, adda, rm, rmw, rmi, cp, mod, set
+	ItemType     string   `xml:"arg1"` // -d, -D, -c, -C, -r, -R, -u, -U
+	ItemName     string   `xml:"arg2"`
+	AttrName     string   `xml:"arg3"`
+	AttrValue    string   `xml:"arg4"`
+	AttrUnits    string   `xml:"arg5"`
+	NewAttrName  string   `xml:"arg6"` // new attr name (for mod)
+	NewAttrValue string   `xml:"arg7"` // new attr value (for mod)
+	NewAttrUnits string   `xml:"arg8"` // new attr unit (for mod)
+	Arg9         string   `xml:"arg9"` // unused
+}
+
+// NewIRODSMessageAddMetadataRequest creates a IRODSMessageModMetaRequest message for adding a metadata AVU on some item.
+// metadata.AVUID is ignored
+func NewIRODSMessageAddMetadataRequest(itemType types.IRODSMetaItemType, itemName string, metadata *types.IRODSMeta) *IRODSMessageModMetaRequest {
+	request := &IRODSMessageModMetaRequest{
+		Operation: "add",
+		ItemType:  string(itemType),
+		ItemName:  itemName,
+		AttrName:  metadata.Name,
+		AttrValue: metadata.Value,
+		AttrUnits: metadata.Units,
+	}
+
+	return request
+}
+
+// NewIRODSMessageReplaceMetadataRequest creates a IRODSMessageModMetaRequest message for replacing a metadata AVU.
+// oldMetadata.AVUID and newMetadata.AVUID are ignored, the old AVU is queried by its name, value and unit.
+func NewIRODSMessageReplaceMetadataRequest(itemType types.IRODSMetaItemType, itemName string, oldMetadata *types.IRODSMeta, newMetadata *types.IRODSMeta) *IRODSMessageModMetaRequest {
+	request := &IRODSMessageModMetaRequest{
+		Operation:    "mod",
+		ItemType:     string(itemType),
+		ItemName:     itemName,
+		AttrName:     oldMetadata.Name,
+		AttrValue:    oldMetadata.Value,
+		AttrUnits:    oldMetadata.Units,
+		NewAttrName:  newMetadata.Name,
+		NewAttrValue: newMetadata.Value,
+		NewAttrUnits: newMetadata.Units,
+	}
+
+	return request
+}
+
+// NewIRODSMessageRemoveMetadataRequest creates a IRODSMessageModMetaRequest message for removing a metadata AVU.
+// metadata.AVUID is ignored, the AVU is queried by its name, value and unit.
+func NewIRODSMessageRemoveMetadataRequest(itemType types.IRODSMetaItemType, itemName string, metadata *types.IRODSMeta) *IRODSMessageModMetaRequest {
+	request := &IRODSMessageModMetaRequest{
+		Operation: "rm",
+		ItemType:  string(itemType),
+		ItemName:  itemName,
+		AttrName:  metadata.Name,
+		AttrValue: metadata.Value,
+		AttrUnits: metadata.Units,
+	}
+
+	return request
+}
+
+// NewIRODSMessageRemoveMetadataByIDRequest creates a IRODSMessageModMetaRequest message for removing a metadata AVU by its AVUID.
+func NewIRODSMessageRemoveMetadataByIDRequest(itemType types.IRODSMetaItemType, itemName string, AVUID int64) *IRODSMessageModMetaRequest {
+	request := &IRODSMessageModMetaRequest{
+		Operation: "rmi",
+		ItemType:  string(itemType),
+		ItemName:  itemName,
+		AttrName:  fmt.Sprintf("%d", AVUID),
+	}
+
+	return request
+}
+
+// NewIRODSMessageSetMetadataRequest creates a IRODSMessageModMetaRequest message for changing the first metadata AVU on the given item with a matching attribute name to the given value an units.
+// metadata.AVUID is ignored.
+func NewIRODSMessageSetMetadataRequest(itemType types.IRODSMetaItemType, itemName string, metadata *types.IRODSMeta) *IRODSMessageModMetaRequest {
+	request := &IRODSMessageModMetaRequest{
+		Operation: "set",
+		ItemType:  string(itemType),
+		ItemName:  itemName,
+		AttrName:  metadata.Name,
+		AttrValue: metadata.Value,
+		AttrUnits: metadata.Units,
+	}
+
+	return request
+}
+
+// GetBytes returns byte array
+func (msg *IRODSMessageModMetaRequest) GetBytes() ([]byte, error) {
+	xmlBytes, err := xml.Marshal(msg)
+	return xmlBytes, err
+}
+
+// FromBytes returns struct from bytes
+func (msg *IRODSMessageModMetaRequest) FromBytes(bytes []byte) error {
+	err := xml.Unmarshal(bytes, msg)
+	return err
+}
+
+// GetMessage builds a message
+func (msg *IRODSMessageModMetaRequest) GetMessage() (*IRODSMessage, error) {
+	bytes, err := msg.GetBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	msgBody := IRODSMessageBody{
+		Type:    RODS_MESSAGE_API_REQ_TYPE,
+		Message: bytes,
+		Error:   nil,
+		Bs:      nil,
+		IntInfo: int32(common.MOD_AVU_METADATA_AN),
+	}
+
+	msgHeader, err := msgBody.BuildHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	return &IRODSMessage{
+		Header: msgHeader,
+		Body:   &msgBody,
+	}, nil
+}

--- a/irods/message/modmeta_response.go
+++ b/irods/message/modmeta_response.go
@@ -1,0 +1,31 @@
+package message
+
+import (
+	"fmt"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+)
+
+// IRODSMessageModMetaResponse stores alter metadata response
+type IRODSMessageModMetaResponse struct {
+	// empty structure
+	Result int
+}
+
+// CheckError returns error if server returned an error
+func (msg *IRODSMessageModMetaResponse) CheckError() error {
+	if msg.Result < 0 {
+		return common.MakeIRODSError(common.ErrorCode(msg.Result))
+	}
+	return nil
+}
+
+// FromMessage returns struct from IRODSMessage
+func (msg *IRODSMessageModMetaResponse) FromMessage(msgIn *IRODSMessage) error {
+	if msgIn.Body == nil {
+		return fmt.Errorf("Cannot create a struct from an empty body")
+	}
+
+	msg.Result = int(msgIn.Body.IntInfo)
+	return nil
+}

--- a/irods/types/meta.go
+++ b/irods/types/meta.go
@@ -2,9 +2,33 @@ package types
 
 import "fmt"
 
+// IRODSMetaItemType describes a type to set metadata on
+type IRODSMetaItemType string
+
+const (
+	IRODSDataObjectMetaItemType IRODSMetaItemType = "-d"
+	IRODSCollectionMetaItemType IRODSMetaItemType = "-C"
+	IRODSResourceMetaItemType   IRODSMetaItemType = "-R"
+	IRODSUserMetaItemType       IRODSMetaItemType = "-u"
+)
+
+// GetIRODSMetaItemType gets the irods metadata item type from an object.
+func GetIRODSMetaItemType(data interface{}) (IRODSMetaItemType, error) {
+	switch data.(type) {
+	case IRODSDataObject:
+		return IRODSDataObjectMetaItemType, nil
+	case IRODSCollection:
+		return IRODSCollectionMetaItemType, nil
+	case IRODSUser:
+		return IRODSUserMetaItemType, nil
+	default:
+		return "", fmt.Errorf("data type is unknown for irods metadata")
+	}
+}
+
 // IRODSMeta contains irods metadata
 type IRODSMeta struct {
-	AVUID int64
+	AVUID int64 // is ignored on metadata operations (set, add, mod, rm)
 	Name  string
 	Value string
 	Units string


### PR DESCRIPTION
This commit adds metadata modification functionality for both data objects and collections. The communication-layer for modification of metadata for resources and users is also aded. The functions AddDataObjectMeta/DeleteDataObjectMeta are tested.

I'm currently using types.IRODSMeta everywhere, but ignoring its AVUID for adding/modificating/removing metadata. If it is preffered, I could create another struct without the AVUID field and let types.IRODSMeta inherit it.

Wrapper functions under FileSystem would probably be useful too, but it needs a good choice of the signatures (e.g. something like the struct FSEntry, a list of "FSMeta"?), and a choice how updates should be performed (delta changes or just completely replace metadata by a new set). If you would like me to add something there in this PR, let me know.

BTW our current usecase is a minimalistic basic golang-based irods web-browser.