### PR TITLE
Add resource, implement rcFileStat

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -582,7 +582,7 @@ func (fs *FileSystem) ReplicateFile(path string, resource string, update bool) e
 	}
 	defer fs.Session.ReturnConnection(conn)
 
-	return irods_fs.ReplicateDataObject(conn, irodsPath, resource, update)
+	return irods_fs.ReplicateDataObject(conn, irodsPath, resource, update, false)
 }
 
 // DownloadFile downloads a file to local

--- a/irods/common/icat_column_number.go
+++ b/irods/common/icat_column_number.go
@@ -83,4 +83,24 @@ const (
 	// Group
 	ICAT_COLUMN_COLL_USER_GROUP_ID   ICATColumnNumber = 900
 	ICAT_COLUMN_COLL_USER_GROUP_NAME ICATColumnNumber = 901
+	
+    // Resource
+	ICAT_COLUMN_R_RESC_ID             ICATColumnNumber = 301
+	ICAT_COLUMN_R_RESC_NAME           ICATColumnNumber = 302
+	ICAT_COLUMN_R_ZONE_NAME           ICATColumnNumber = 303
+	ICAT_COLUMN_R_TYPE_NAME           ICATColumnNumber = 304
+	ICAT_COLUMN_R_CLASS_NAME          ICATColumnNumber = 305
+	ICAT_COLUMN_R_LOC                 ICATColumnNumber = 306
+	ICAT_COLUMN_R_VAULT_PATH          ICATColumnNumber = 307
+	ICAT_COLUMN_R_FREE_SPACE          ICATColumnNumber = 308
+	ICAT_COLUMN_R_RESC_INFO           ICATColumnNumber = 309
+	ICAT_COLUMN_R_RESC_COMMENT        ICATColumnNumber = 310
+	ICAT_COLUMN_R_CREATE_TIME         ICATColumnNumber = 311
+	ICAT_COLUMN_R_MODIFY_TIME         ICATColumnNumber = 312
+	ICAT_COLUMN_R_RESC_STATUS         ICATColumnNumber = 313
+	ICAT_COLUMN_R_FREE_SPACE_TIME     ICATColumnNumber = 314
+	ICAT_COLUMN_R_RESC_CHILDREN       ICATColumnNumber = 315
+	ICAT_COLUMN_R_RESC_CONTEXT        ICATColumnNumber = 316
+	ICAT_COLUMN_R_RESC_PARENT         ICATColumnNumber = 317
+	ICAT_COLUMN_R_RESC_PARENT_CONTEXT ICATColumnNumber = 318
 )

--- a/irods/common/keywords.go
+++ b/irods/common/keywords.go
@@ -10,4 +10,7 @@ const (
 	DATA_TYPE_KW      KeyWord = "dataType"
 	OPR_TYPE_KW       KeyWord = "oprType"
 	UPDATE_REPL_KW    KeyWord = "updateRepl"
+	RESC_NAME_KW      KeyWord = "rescName"
+	COPIES_KW         KeyWord = "copies"
+	AGE_KW            KeyWord = "age"
 )

--- a/irods/common/keywords.go
+++ b/irods/common/keywords.go
@@ -13,4 +13,5 @@ const (
 	RESC_NAME_KW      KeyWord = "rescName"
 	COPIES_KW         KeyWord = "copies"
 	AGE_KW            KeyWord = "age"
+	ADMIN_KW          KeyWord = "irodsAdmin"
 )

--- a/irods/fs/data_object.go
+++ b/irods/fs/data_object.go
@@ -1068,7 +1068,7 @@ func TruncateDataObject(conn *connection.IRODSConnection, path string, size int6
 }
 
 // ReplicateDataObject replicates a data object for the path to the given reousrce
-func ReplicateDataObject(conn *connection.IRODSConnection, path string, resource string, update bool) error {
+func ReplicateDataObject(conn *connection.IRODSConnection, path string, resource string, update bool, adminFlag bool) error {
 	if conn == nil || !conn.IsConnected() {
 		return fmt.Errorf("connection is nil or disconnected")
 	}
@@ -1077,6 +1077,10 @@ func ReplicateDataObject(conn *connection.IRODSConnection, path string, resource
 
 	if update {
 		request.AddKeyVal(common.UPDATE_REPL_KW, "")
+	}
+
+	if adminFlag {
+		request.AddKeyVal(common.ADMIN_KW, "")
 	}
 
 	requestMessage, err := request.GetMessage()
@@ -1106,12 +1110,16 @@ func ReplicateDataObject(conn *connection.IRODSConnection, path string, resource
 }
 
 // TrimDataObject trims replicas for a data object
-func TrimDataObject(conn *connection.IRODSConnection, path string, resource string, minCopies int, minAgeMinutes int) error {
+func TrimDataObject(conn *connection.IRODSConnection, path string, resource string, minCopies int, minAgeMinutes int, adminFlag bool) error {
 	if conn == nil || !conn.IsConnected() {
 		return fmt.Errorf("connection is nil or disconnected")
 	}
 
 	request := message.NewIRODSMessageTrimobjRequest(path, resource, minCopies, minAgeMinutes)
+
+	if adminFlag {
+		request.AddKeyVal(common.ADMIN_KW, "")
+	}
 
 	requestMessage, err := request.GetMessage()
 	if err != nil {

--- a/irods/fs/data_object.go
+++ b/irods/fs/data_object.go
@@ -1105,6 +1105,40 @@ func ReplicateDataObject(conn *connection.IRODSConnection, path string, resource
 	return err
 }
 
+// TrimDataObject trims replicas for a data object
+func TrimDataObject(conn *connection.IRODSConnection, path string, resource string, minCopies int, minAgeMinutes int) error {
+	if conn == nil || !conn.IsConnected() {
+		return fmt.Errorf("connection is nil or disconnected")
+	}
+
+	request := message.NewIRODSMessageTrimobjRequest(path, resource, minCopies, minAgeMinutes)
+
+	requestMessage, err := request.GetMessage()
+	if err != nil {
+		return fmt.Errorf("Could not make a data object trim request message - %v", err)
+	}
+
+	err = conn.SendMessage(requestMessage)
+	if err != nil {
+		return fmt.Errorf("Could not send a data object trim request message - %v", err)
+	}
+
+	// Server responds with results
+	responseMessage, err := conn.ReadMessage()
+	if err != nil {
+		return fmt.Errorf("Could not receive a data object trim response message - %v", err)
+	}
+
+	response := message.IRODSMessageTrimobjResponse{}
+	err = response.FromMessage(responseMessage)
+	if err != nil {
+		return fmt.Errorf("Could not receive a data object trim response message - %v", err)
+	}
+
+	err = response.CheckError()
+	return err
+}
+
 // CreateDataObject creates a data object for the path, returns a file handle
 func CreateDataObject(conn *connection.IRODSConnection, path string, resource string, force bool) (*types.IRODSFileHandle, error) {
 	if conn == nil || !conn.IsConnected() {

--- a/irods/fs/data_object_bulk.go
+++ b/irods/fs/data_object_bulk.go
@@ -52,7 +52,7 @@ func UploadDataObject(conn *connection.IRODSConnection, localPath string, irodsP
 	var replErr error
 	// replicate
 	if replicate {
-		err = ReplicateDataObject(conn, irodsPath, "", true)
+		err = ReplicateDataObject(conn, irodsPath, "", true, false)
 		replErr = err
 	}
 

--- a/irods/fs/resource.go
+++ b/irods/fs/resource.go
@@ -1,0 +1,191 @@
+package fs
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+	"github.com/cyverse/go-irodsclient/irods/connection"
+	"github.com/cyverse/go-irodsclient/irods/message"
+	"github.com/cyverse/go-irodsclient/irods/types"
+	"github.com/cyverse/go-irodsclient/irods/util"
+)
+
+// GetResource returns a data object for the path
+func GetResource(conn *connection.IRODSConnection, name string) (*types.IRODSResource, error) {
+	if conn == nil || !conn.IsConnected() {
+		return nil, fmt.Errorf("connection is nil or disconnected")
+	}
+
+	// resource
+	query := message.NewIRODSMessageQuery(1, 0, 0, 0)
+	query.AddSelect(common.ICAT_COLUMN_R_RESC_ID, 1)
+	query.AddSelect(common.ICAT_COLUMN_R_RESC_NAME, 1)
+	query.AddSelect(common.ICAT_COLUMN_R_ZONE_NAME, 1)
+	query.AddSelect(common.ICAT_COLUMN_R_TYPE_NAME, 1)
+	query.AddSelect(common.ICAT_COLUMN_R_CLASS_NAME, 1)
+	query.AddSelect(common.ICAT_COLUMN_R_LOC, 1)
+	query.AddSelect(common.ICAT_COLUMN_R_VAULT_PATH, 1)
+	query.AddSelect(common.ICAT_COLUMN_R_RESC_CONTEXT, 1)
+	query.AddSelect(common.ICAT_COLUMN_R_CREATE_TIME, 1)
+	query.AddSelect(common.ICAT_COLUMN_R_MODIFY_TIME, 1)
+
+	rescCondVal := fmt.Sprintf("= '%s'", name)
+	query.AddCondition(common.ICAT_COLUMN_R_RESC_NAME, rescCondVal)
+
+	queryMessage, err := query.GetMessage()
+	if err != nil {
+		return nil, fmt.Errorf("Could not make a data object query message - %v", err)
+	}
+
+	err = conn.SendMessage(queryMessage)
+	if err != nil {
+		return nil, fmt.Errorf("Could not send a data object query message - %v", err)
+	}
+
+	// Server responds with results
+	queryResultMessage, err := conn.ReadMessage()
+	if err != nil {
+		return nil, fmt.Errorf("Could not receive a data object query result message - %v", err)
+	}
+
+	queryResult := message.IRODSMessageQueryResult{}
+	err = queryResult.FromMessage(queryResultMessage)
+	if err != nil {
+		return nil, fmt.Errorf("Could not receive a data object query result message - %v", err)
+	}
+
+	if queryResult.RowCount == 0 {
+		return nil, errors.New("No row found")
+	}
+
+	if queryResult.AttributeCount > len(queryResult.SQLResult) {
+		return nil, fmt.Errorf("Could not receive data object attributes - requires %d, but received %d attributes", queryResult.AttributeCount, len(queryResult.SQLResult))
+	}
+
+	resource := &types.IRODSResource{}
+
+	for attr := 0; attr < queryResult.AttributeCount; attr++ {
+		sqlResult := queryResult.SQLResult[attr]
+		if len(sqlResult.Values) != queryResult.RowCount {
+			return nil, fmt.Errorf("Could not receive data object rows - requires %d, but received %d attributes", queryResult.RowCount, len(sqlResult.Values))
+		}
+
+		value := sqlResult.Values[0]
+
+		switch sqlResult.AttributeIndex {
+		case int(common.ICAT_COLUMN_R_RESC_ID):
+			objID, err := strconv.ParseInt(value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("Could not parse resource id - %s", value)
+			}
+			resource.RescID = objID
+		case int(common.ICAT_COLUMN_R_RESC_NAME):
+			resource.Name = value
+		case int(common.ICAT_COLUMN_R_ZONE_NAME):
+			resource.Zone = value
+		case int(common.ICAT_COLUMN_R_TYPE_NAME):
+			resource.Type = value
+		case int(common.ICAT_COLUMN_R_CLASS_NAME):
+			resource.Class = value
+		case int(common.ICAT_COLUMN_R_LOC):
+			resource.Location = value
+		case int(common.ICAT_COLUMN_R_VAULT_PATH):
+			resource.Path = value
+		case int(common.ICAT_COLUMN_R_RESC_CONTEXT):
+			resource.Context = value
+		case int(common.ICAT_COLUMN_R_CREATE_TIME):
+			cT, err := util.GetIRODSDateTime(value)
+			if err != nil {
+				return nil, fmt.Errorf("Could not parse create time - %s", value)
+			}
+			resource.CreateTime = cT
+		case int(common.ICAT_COLUMN_R_MODIFY_TIME):
+			mT, err := util.GetIRODSDateTime(value)
+			if err != nil {
+				return nil, fmt.Errorf("Could not parse modify time - %s", value)
+			}
+			resource.ModifyTime = mT
+		default:
+			// ignore
+		}
+	}
+
+	return resource, nil
+}
+
+// AddResourceMeta sets metadata of a resource to the given key values.
+// metadata.AVUID is ignored
+func AddResourceMeta(conn *connection.IRODSConnection, name string, metadata *types.IRODSMeta) error {
+	if conn == nil || !conn.IsConnected() {
+		return fmt.Errorf("connection is nil or disconnected")
+	}
+
+	request := message.NewIRODSMessageAddMetadataRequest(types.IRODSResourceMetaItemType, name, metadata)
+	requestMessage, err := request.GetMessage()
+	if err != nil {
+		return fmt.Errorf("Could not make a metadata modification request message - %v", err)
+	}
+
+	err = conn.SendMessage(requestMessage)
+	if err != nil {
+		return fmt.Errorf("Could not send a metadata modification request message - %v", err)
+	}
+
+	// Server responds with results
+	responseMessage, err := conn.ReadMessage()
+	if err != nil {
+		return fmt.Errorf("Could not receive a metadata modification response message - %v", err)
+	}
+
+	response := message.IRODSMessageModMetaResponse{}
+	err = response.FromMessage(responseMessage)
+	if err != nil {
+		return fmt.Errorf("Could not receive a metadata modification response message - %v", err)
+	}
+
+	err = response.CheckError()
+	return err
+}
+
+// DeleteResourceMeta sets metadata of a resource to the given key values.
+// The metadata AVU is selected on basis of AVUID if it is supplied, otherwise on basis of Name, Value and Units.
+func DeleteResourceMeta(conn *connection.IRODSConnection, name string, metadata *types.IRODSMeta) error {
+	if conn == nil || !conn.IsConnected() {
+		return fmt.Errorf("connection is nil or disconnected")
+	}
+
+	var request *message.IRODSMessageModMetaRequest
+
+	if metadata.AVUID != 0 {
+		request = message.NewIRODSMessageRemoveMetadataByIDRequest(types.IRODSResourceMetaItemType, name, metadata.AVUID)
+	} else {
+		request = message.NewIRODSMessageRemoveMetadataRequest(types.IRODSResourceMetaItemType, name, metadata)
+	}
+
+	requestMessage, err := request.GetMessage()
+	if err != nil {
+		return fmt.Errorf("Could not make a metadata modification request message - %v", err)
+	}
+
+	err = conn.SendMessage(requestMessage)
+	if err != nil {
+		return fmt.Errorf("Could not send a metadata modification request message - %v", err)
+	}
+
+	// Server responds with results
+	responseMessage, err := conn.ReadMessage()
+	if err != nil {
+		return fmt.Errorf("Could not receive a metadata modification response message - %v", err)
+	}
+
+	response := message.IRODSMessageModMetaResponse{}
+	err = response.FromMessage(responseMessage)
+	if err != nil {
+		return fmt.Errorf("Could not receive a metadata modification response message - %v", err)
+	}
+
+	err = response.CheckError()
+	return err
+}

--- a/irods/fs/resource.go
+++ b/irods/fs/resource.go
@@ -18,8 +18,8 @@ func GetResource(conn *connection.IRODSConnection, name string) (*types.IRODSRes
 		return nil, fmt.Errorf("connection is nil or disconnected")
 	}
 
-	// resource
-	query := message.NewIRODSMessageQuery(1, 0, 0, 0)
+	// query with AUTO_CLOSE option
+	query := message.NewIRODSMessageQuery(1, 0, 0, 0x100)
 	query.AddSelect(common.ICAT_COLUMN_R_RESC_ID, 1)
 	query.AddSelect(common.ICAT_COLUMN_R_RESC_NAME, 1)
 	query.AddSelect(common.ICAT_COLUMN_R_ZONE_NAME, 1)
@@ -54,6 +54,10 @@ func GetResource(conn *connection.IRODSConnection, name string) (*types.IRODSRes
 	err = queryResult.FromMessage(queryResultMessage)
 	if err != nil {
 		return nil, fmt.Errorf("Could not receive a data object query result message - %v", err)
+	}
+
+	if queryResult.ContinueIndex != 0 {
+		util.LogDebugf("resource query for %s would have continued, more than one result found\n", name)
 	}
 
 	if queryResult.RowCount == 0 {

--- a/irods/message/filestat_request.go
+++ b/irods/message/filestat_request.go
@@ -1,0 +1,79 @@
+package message
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+	"github.com/cyverse/go-irodsclient/irods/types"
+)
+
+// IRODSMessageFileStatRequest stores file stat request
+type IRODSMessageFileStatRequest struct {
+	XMLName           xml.Name         `xml:"fileStatInp_PI"`
+	Host              IRODSMessageHost `xml:"RHostAddr_PI"`
+	Path              string           `xml:"fileName"`
+	ResourceHierarchy string           `xml:"rescHier"`
+	ObjectPath        string           `xml:"objPath"`
+	ResourceID        int64            `xml:"rescId"`
+}
+
+// NewIRODSMessageFileStatRequest creates a IRODSMessageFileStatRequest message
+func NewIRODSMessageFileStatRequest(resource *types.IRODSResource, obj *types.IRODSDataObject, replica *types.IRODSReplica) (*IRODSMessageFileStatRequest, error) {
+	host, err := NewIRODSMessageHost(resource)
+	if err != nil {
+		return nil, err
+	}
+
+	if resource.Name != replica.ResourceName {
+		return nil, fmt.Errorf("Resource name %s does not match replica resource name %s", resource.Name, replica.ResourceName)
+	}
+
+	request := &IRODSMessageFileStatRequest{
+		Host:              *host,
+		Path:              replica.Path,
+		ResourceHierarchy: replica.ResourceHierarchy,
+		ObjectPath:        obj.Path,
+		ResourceID:        resource.RescID,
+	}
+
+	return request, nil
+}
+
+// GetBytes returns byte array
+func (msg *IRODSMessageFileStatRequest) GetBytes() ([]byte, error) {
+	xmlBytes, err := xml.Marshal(msg)
+	return xmlBytes, err
+}
+
+// FromBytes returns struct from bytes
+func (msg *IRODSMessageFileStatRequest) FromBytes(bytes []byte) error {
+	err := xml.Unmarshal(bytes, msg)
+	return err
+}
+
+// GetMessage builds a message
+func (msg *IRODSMessageFileStatRequest) GetMessage() (*IRODSMessage, error) {
+	bytes, err := msg.GetBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	msgBody := IRODSMessageBody{
+		Type:    RODS_MESSAGE_API_REQ_TYPE,
+		Message: bytes,
+		Error:   nil,
+		Bs:      nil,
+		IntInfo: int32(common.FILE_STAT_AN),
+	}
+
+	msgHeader, err := msgBody.BuildHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	return &IRODSMessage{
+		Header: msgHeader,
+		Body:   &msgBody,
+	}, nil
+}

--- a/irods/message/filestat_response.go
+++ b/irods/message/filestat_response.go
@@ -1,0 +1,46 @@
+package message
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// IRODSMessageFileStatResponse stores data object read response
+type IRODSMessageFileStatResponse struct {
+	XMLName    xml.Name `xml:"RODS_STAT_T_PI"`
+	Size       int64    `xml:"st_size"`
+	Dev        int      `xml:"st_dev"`
+	Ino        int      `xml:"st_ino"`
+	Mode       int      `xml:"st_mode"`
+	Links      int      `xml:"st_nlink"`
+	UID        int      `xml:"st_uid"`
+	GID        int      `xml:"st_gid"`
+	Rdev       int      `xml:"st_rdev"`
+	AccessTime int      `xml:"st_atim"`
+	ModifyTime int      `xml:"st_mtim"`
+	ChangeTime int      `xml:"st_ctim"`
+	BlkSize    int      `xml:"st_blksize"`
+	Blocks     int      `xml:"st_blocks"`
+}
+
+// GetBytes returns byte array
+func (msg *IRODSMessageFileStatResponse) GetBytes() ([]byte, error) {
+	xmlBytes, err := xml.Marshal(msg)
+	return xmlBytes, err
+}
+
+// FromBytes returns struct from bytes
+func (msg *IRODSMessageFileStatResponse) FromBytes(bytes []byte) error {
+	err := xml.Unmarshal(bytes, msg)
+	return err
+}
+
+// FromMessage returns struct from IRODSMessage
+func (msg *IRODSMessageFileStatResponse) FromMessage(msgIn *IRODSMessage) error {
+	if msgIn.Body == nil {
+		return fmt.Errorf("Cannot create a struct from an empty body")
+	}
+
+	err := msg.FromBytes(msgIn.Body.Message)
+	return err
+}

--- a/irods/message/host.go
+++ b/irods/message/host.go
@@ -1,0 +1,62 @@
+package message
+
+import (
+	"encoding/xml"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/cyverse/go-irodsclient/irods/types"
+)
+
+// IRODSMessageHost stores startup message
+type IRODSMessageHost struct {
+	XMLName  xml.Name `xml:"RHostAddr_PI"`
+	Addr     string   `xml:"hostAddr"`
+	Zone     string   `xml:"rodsZone"`
+	Port     int      `xml:"port"`
+	DummyInt int      `xml:"dummyInt"`
+}
+
+// NewIRODSMessageHost creates a IRODSMessageHost message
+func NewIRODSMessageHost(resource *types.IRODSResource) (*IRODSMessageHost, error) {
+	var (
+		addr       string
+		port       int
+		portString string
+		err        error
+	)
+
+	if strings.ContainsAny(resource.Location, ":") {
+		addr, portString, err = net.SplitHostPort(resource.Location)
+		if err != nil {
+			return nil, err
+		}
+
+		port, err = strconv.Atoi(portString)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		addr = resource.Location
+		port = 1247
+	}
+
+	return &IRODSMessageHost{
+		Addr: addr,
+		Zone: resource.Zone,
+		Port: port,
+	}, nil
+}
+
+// GetBytes returns byte array
+func (msg *IRODSMessageHost) GetBytes() ([]byte, error) {
+	xmlBytes, err := xml.Marshal(msg)
+	return xmlBytes, err
+}
+
+// FromBytes returns struct from bytes
+func (msg *IRODSMessageHost) FromBytes(bytes []byte) error {
+	err := xml.Unmarshal(bytes, msg)
+	return err
+}

--- a/irods/message/trimobj_request.go
+++ b/irods/message/trimobj_request.go
@@ -1,0 +1,84 @@
+package message
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+)
+
+// IRODSMessageTrimobjRequest stores data object replication request
+type IRODSMessageTrimobjRequest IRODSMessageDataObjectRequest
+
+// NewIRODSMessageTrimobjRequest creates a IRODSMessageReplobjRequest message
+func NewIRODSMessageTrimobjRequest(path string, resource string, minCopies int, minAgeMinutes int) *IRODSMessageTrimobjRequest {
+	request := &IRODSMessageTrimobjRequest{
+		Path:          path,
+		CreateMode:    0,
+		OpenFlags:     0,
+		Offset:        0,
+		Size:          -1,
+		Threads:       0,
+		OperationType: 0,
+		KeyVals: IRODSMessageSSKeyVal{
+			Length: 0,
+		},
+	}
+
+	if len(resource) > 0 {
+		request.KeyVals.Add(string(common.RESC_NAME_KW), resource)
+	}
+
+	if minCopies > 0 {
+		request.KeyVals.Add(string(common.COPIES_KW), fmt.Sprintf("%d", minCopies))
+	}
+
+	if minAgeMinutes > 0 {
+		request.KeyVals.Add(string(common.AGE_KW), fmt.Sprintf("%d", minAgeMinutes))
+	}
+
+	return request
+}
+
+// AddKeyVal adds a key-value pair
+func (msg *IRODSMessageTrimobjRequest) AddKeyVal(key common.KeyWord, val string) {
+	msg.KeyVals.Add(string(key), val)
+}
+
+// GetBytes returns byte array
+func (msg *IRODSMessageTrimobjRequest) GetBytes() ([]byte, error) {
+	xmlBytes, err := xml.Marshal(msg)
+	return xmlBytes, err
+}
+
+// FromBytes returns struct from bytes
+func (msg *IRODSMessageTrimobjRequest) FromBytes(bytes []byte) error {
+	err := xml.Unmarshal(bytes, msg)
+	return err
+}
+
+// GetMessage builds a message
+func (msg *IRODSMessageTrimobjRequest) GetMessage() (*IRODSMessage, error) {
+	bytes, err := msg.GetBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	msgBody := IRODSMessageBody{
+		Type:    RODS_MESSAGE_API_REQ_TYPE,
+		Message: bytes,
+		Error:   nil,
+		Bs:      nil,
+		IntInfo: int32(common.DATA_OBJ_TRIM_AN),
+	}
+
+	msgHeader, err := msgBody.BuildHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	return &IRODSMessage{
+		Header: msgHeader,
+		Body:   &msgBody,
+	}, nil
+}

--- a/irods/message/trimobj_response.go
+++ b/irods/message/trimobj_response.go
@@ -1,0 +1,31 @@
+package message
+
+import (
+	"fmt"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+)
+
+// IRODSMessageTrimobjResponse stores data object trim response
+type IRODSMessageTrimobjResponse struct {
+	// empty structure
+	Result int
+}
+
+// CheckError returns error if server returned an error
+func (msg *IRODSMessageTrimobjResponse) CheckError() error {
+	if msg.Result < 0 {
+		return common.MakeIRODSError(common.ErrorCode(msg.Result))
+	}
+	return nil
+}
+
+// FromMessage returns struct from IRODSMessage
+func (msg *IRODSMessageTrimobjResponse) FromMessage(msgIn *IRODSMessage) error {
+	if msgIn.Body == nil {
+		return fmt.Errorf("Cannot create a struct from an empty body")
+	}
+
+	msg.Result = int(msgIn.Body.IntInfo)
+	return nil
+}

--- a/irods/types/resource.go
+++ b/irods/types/resource.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"fmt"
+	"time"
+)
+
+// IRODSResource describes a resource host
+type IRODSResource struct {
+	RescID   int64
+	Name     string
+	Zone     string
+	Type     string
+	Class    string
+	Location string
+
+	// Path has the path string of the resource
+	Path string
+
+	// Context has the context string
+	Context string
+
+	// CreateTime has creation time
+	CreateTime time.Time
+	// ModifyTime has last modified time
+	ModifyTime time.Time
+}
+
+// ToString stringifies the object
+func (res *IRODSResource) ToString() string {
+	return fmt.Sprintf("<IRODSResource %s: %v>", res.Name, res)
+}


### PR DESCRIPTION
Add querying of Resource information. Implement the rcFileStat function
to retrieve stat of a file from the resource.

The following code was used to test, but I am wondering whether it might already be too specific to add. But the low-level communication of course should be in this module.

```golang

import (
	"fmt"

	"github.com/cyverse/go-irodsclient/irods/connection"
	"github.com/cyverse/go-irodsclient/irods/message"
	"github.com/cyverse/go-irodsclient/irods/types"
)

func Stat(conn *connection.IRODSConnection, resource *types.IRODSResource, obj *types.IRODSDataObject, replica *types.IRODSReplica) (*message.IRODSMessageFileStatResponse, error) {
	stat, err := message.NewIRODSMessageFileStatRequest(resource, obj, replica)
	if err != nil {
		return nil, fmt.Errorf("%w: %v", ErrPrepareMessage, err)
	}

	queryMessage, err := stat.GetMessage()
	if err != nil {
		return nil, fmt.Errorf("%w: %v", ErrPrepareMessage, err)
	}

	err = conn.SendMessage(queryMessage)
	if err != nil {
		return nil, fmt.Errorf("%w: %v", ErrSendMessage, err)
	}

	// Server responds with results
	queryResultMessage, err := conn.ReadMessage()
	if err != nil {
		return nil, fmt.Errorf("%w: %v", ErrReceiveMessage, err)
	}

	queryResult := &message.IRODSMessageFileStatResponse{}

	err = queryResult.FromMessage(queryResultMessage)
	if err != nil {
		return nil, fmt.Errorf("%w: %v", ErrParseMessage, err)
	}

	return queryResult, nil
}
```

Signed-off-by: Peter Verraedt <peter@verraedt.be>