### PR TITLE
Check if cached collections and data objects are of the correct type

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -776,7 +776,7 @@ func (fs *FileSystem) InvalidateCache(path string) {
 func (fs *FileSystem) getCollection(path string) (*FSEntry, error) {
 	// check cache first
 	cachedEntry := fs.Cache.GetEntryCache(path)
-	if cachedEntry != nil {
+	if cachedEntry != nil && cachedEntry.Type == FSDirectoryEntry {
 		return cachedEntry, nil
 	}
 
@@ -915,7 +915,7 @@ func (fs *FileSystem) listEntries(collection *types.IRODSCollection) ([]*FSEntry
 func (fs *FileSystem) getDataObject(path string) (*FSEntry, error) {
 	// check cache first
 	cachedEntry := fs.Cache.GetEntryCache(path)
-	if cachedEntry != nil {
+	if cachedEntry != nil && cachedEntry.Type == FSFileEntry {
 		return cachedEntry, nil
 	}
 


### PR DESCRIPTION
In our use case, we encountered a problem where collections are returned from the EntryCache when we expect data objects (or vice versa). This happens when we used the ListMetadata function which executes the ExistsDir function (from the fs/fs package), which itself uses getCollection to get Entries (from cache). 

With this commit, we check if the FSEntry is of the right Type (directory / collection of file / data object) and only returns it from cache if the type is as expected.

Signed-off-by: Jan Bongers <jan.bongers@kuleuven.be>