### PR TITLE
Fix caching issues related to GroupUsers.

### DIFF
--- a/fs/cache.go
+++ b/fs/cache.go
@@ -150,7 +150,7 @@ func (cache *FileSystemCache) ClearMetadataCache() {
 }
 
 // AddGroupUsersCache ...
-func (cache *FileSystemCache) AddGroupUsersCache(group string, users []types.IRODSUser) {
+func (cache *FileSystemCache) AddGroupUsersCache(group string, users []*types.IRODSUser) {
 	cache.GroupUsersCache.Set(group, users, 0)
 }
 
@@ -160,10 +160,10 @@ func (cache *FileSystemCache) RemoveGroupUsersCache(group string) {
 }
 
 // GetGroupUsersCache ...
-func (cache *FileSystemCache) GetGroupUsersCache(group string) []types.IRODSUser {
+func (cache *FileSystemCache) GetGroupUsersCache(group string) []*types.IRODSUser {
 	users, exist := cache.GroupUsersCache.Get(group)
 	if exist {
-		if irodsUsers, ok := users.([]types.IRODSUser); ok {
+		if irodsUsers, ok := users.([]*types.IRODSUser); ok {
 			return irodsUsers
 		}
 	}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -65,13 +65,7 @@ func (fs *FileSystem) ListGroupUsers(group string) ([]*types.IRODSUser, error) {
 	// check cache first
 	cachedUsers := fs.Cache.GetGroupUsersCache(group)
 	if cachedUsers != nil {
-		// convert it to pointer arrays
-		userArray := []*types.IRODSUser{}
-		for _, cu := range cachedUsers {
-			userArray = append(userArray, &cu)
-		}
-
-		return userArray, nil
+		return cachedUsers, nil
 	}
 
 	// otherwise, retrieve it and add it to cache
@@ -87,13 +81,7 @@ func (fs *FileSystem) ListGroupUsers(group string) ([]*types.IRODSUser, error) {
 	}
 
 	// cache it
-	// convert it to arrays
-	userArray := []types.IRODSUser{}
-	for _, u := range users {
-		userArray = append(userArray, *u)
-	}
-
-	fs.Cache.AddGroupUsersCache(group, userArray)
+	fs.Cache.AddGroupUsersCache(group, users)
 
 	return users, nil
 }


### PR DESCRIPTION
The code to convert GroupUsers to pointers is problematic, and will
result in an array of identical pointers, all pointing to the last
cached IRODSUser. We avoid this by caching pointers instead.

```
// convert it to pointer arrays
userArray := []*types.IRODSUser{}
for _, cu := range cachedUsers {
    userArray = append(userArray, &cu)
}
```

Signed-off-by: Peter Verraedt <peter@verraedt.be>