### PR TITLE
WIP: End transaction request/response

### DIFF
--- a/irods/common/keywords.go
+++ b/irods/common/keywords.go
@@ -3,15 +3,16 @@ package common
 type KeyWord string
 
 const (
-	ZONE_KW           KeyWord = "zone"
-	RECURSIVE_OPR_KW  KeyWord = "recursiveOpr"
-	FORCE_FLAG_KW     KeyWord = "forceFlag"
-	DEST_RESC_NAME_KW KeyWord = "destRescName"
-	DATA_TYPE_KW      KeyWord = "dataType"
-	OPR_TYPE_KW       KeyWord = "oprType"
-	UPDATE_REPL_KW    KeyWord = "updateRepl"
-	RESC_NAME_KW      KeyWord = "rescName"
-	COPIES_KW         KeyWord = "copies"
-	AGE_KW            KeyWord = "age"
-	ADMIN_KW          KeyWord = "irodsAdmin"
+	ZONE_KW            KeyWord = "zone"
+	RECURSIVE_OPR_KW   KeyWord = "recursiveOpr"
+	FORCE_FLAG_KW      KeyWord = "forceFlag"
+	DEST_RESC_NAME_KW  KeyWord = "destRescName"
+	DATA_TYPE_KW       KeyWord = "dataType"
+	OPR_TYPE_KW        KeyWord = "oprType"
+	UPDATE_REPL_KW     KeyWord = "updateRepl"
+	RESC_NAME_KW       KeyWord = "rescName"
+	COPIES_KW          KeyWord = "copies"
+	AGE_KW             KeyWord = "age"
+	ADMIN_KW           KeyWord = "irodsAdmin"
+	COLLECTION_TYPE_KW KeyWord = "collectionType"
 )

--- a/irods/connection/connection.go
+++ b/irods/connection/connection.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cyverse/go-irodsclient/irods/auth"
+	"github.com/cyverse/go-irodsclient/irods/common"
 	"github.com/cyverse/go-irodsclient/irods/message"
 	"github.com/cyverse/go-irodsclient/irods/types"
 	"github.com/cyverse/go-irodsclient/irods/util"
@@ -602,14 +603,28 @@ func (conn *IRODSConnection) ReadMessage() (*message.IRODSMessage, error) {
 func (conn *IRODSConnection) release(val bool) {
 }
 
-// Commit a transaction.
+// Commit a transaction. This is useful in combination with the NO_COMMIT_FLAG.
+// Usage is limited to privileged accounts.
 func (conn *IRODSConnection) Commit() error {
 	return conn.endTransaction(true)
 }
 
-// Rollback a transaction.
+// Rollback a transaction. This is useful in combination with the NO_COMMIT_FLAG.
+// It can also be used to clear the current database transaction if there are no staged operations,
+// just to refresh the view on the database for future queries.
+// Usage is limited to privileged accounts.
 func (conn *IRODSConnection) Rollback() error {
 	return conn.endTransaction(false)
+}
+
+// PoorMansRollback rolls back a transaction as a nonprivileged account, bypassing API limitations.
+// A nonprivileged account cannot have staged operations, so rollback is always a no-op.
+// The usage for this function, is that rolling back the current database transaction still will start
+// a new one, so that future queries will see all changes that where made up to calling this function.
+func (conn *IRODSConnection) PoorMansRollback() error {
+	dummyCol := fmt.Sprintf("/%s/home/%s", conn.Account.ClientZone, conn.Account.ClientUser)
+
+	return conn.poorMansEndTransaction(dummyCol, false)
 }
 
 func (conn *IRODSConnection) endTransaction(commit bool) error {
@@ -634,6 +649,50 @@ func (conn *IRODSConnection) endTransaction(commit bool) error {
 	err = response.FromMessage(responseMessage)
 	if err != nil {
 		return fmt.Errorf("Could not receive a end transaction response message - %v", err)
+	}
+
+	err = response.CheckError()
+	return err
+}
+
+func (conn *IRODSConnection) poorMansEndTransaction(dummyCol string, commit bool) error {
+	request := message.NewIRODSMessageModColRequest(dummyCol)
+
+	if commit {
+		request.AddKeyVal(common.COLLECTION_TYPE_KW, "NULL_SPECIAL_VALUE")
+	}
+
+	requestMessage, err := request.GetMessage()
+	if err != nil {
+		return fmt.Errorf("Could not make a poor mans end transaction request message - %v", err)
+	}
+
+	err = conn.SendMessage(requestMessage)
+	if err != nil {
+		return fmt.Errorf("Could not send a poor mans end transaction request message - %v", err)
+	}
+
+	// Server responds with results
+	responseMessage, err := conn.ReadMessage()
+	if err != nil {
+		return fmt.Errorf("Could not receive a poor mans end transaction response message - %v", err)
+	}
+
+	response := message.IRODSMessageModColResponse{}
+	err = response.FromMessage(responseMessage)
+	if err != nil {
+		return fmt.Errorf("Could not receive a poor mans end transaction response message - %v", err)
+	}
+
+	if !commit {
+		// We do expect an error on rollback because we didn't supply enough parameters
+		if common.ErrorCode(response.Result) == common.CAT_INVALID_ARGUMENT {
+			return nil
+		}
+
+		if response.Result == 0 {
+			return fmt.Errorf("expected an error, but transaction completed successfully")
+		}
 	}
 
 	err = response.CheckError()

--- a/irods/message/endtransaction_request.go
+++ b/irods/message/endtransaction_request.go
@@ -1,0 +1,67 @@
+package message
+
+import (
+	"encoding/xml"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+)
+
+// IRODSMessageEndTransactionRequest stores collection creation request
+type IRODSMessageEndTransactionRequest struct {
+	XMLName  xml.Name `xml:"endTransactionInp_PI"`
+	Action   string   `xml:"arg0"`
+	Argument string   `xml:"arg1"` // unused
+}
+
+// NewIRODSMessageEndTransactionRequest creates a IRODSMessageEndTransactionRequest message
+func NewIRODSMessageEndTransactionRequest(commit bool) *IRODSMessageEndTransactionRequest {
+	var action string
+
+	if commit {
+		action = "commit"
+	} else {
+		action = "rollback"
+	}
+
+	return &IRODSMessageEndTransactionRequest{
+		Action: action,
+	}
+}
+
+// GetBytes returns byte array
+func (msg *IRODSMessageEndTransactionRequest) GetBytes() ([]byte, error) {
+	xmlBytes, err := xml.Marshal(msg)
+	return xmlBytes, err
+}
+
+// FromBytes returns struct from bytes
+func (msg *IRODSMessageEndTransactionRequest) FromBytes(bytes []byte) error {
+	err := xml.Unmarshal(bytes, msg)
+	return err
+}
+
+// GetMessage builds a message
+func (msg *IRODSMessageEndTransactionRequest) GetMessage() (*IRODSMessage, error) {
+	bytes, err := msg.GetBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	msgBody := IRODSMessageBody{
+		Type:    RODS_MESSAGE_API_REQ_TYPE,
+		Message: bytes,
+		Error:   nil,
+		Bs:      nil,
+		IntInfo: int32(common.END_TRANSACTION_AN),
+	}
+
+	msgHeader, err := msgBody.BuildHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	return &IRODSMessage{
+		Header: msgHeader,
+		Body:   &msgBody,
+	}, nil
+}

--- a/irods/message/endtransaction_response.go
+++ b/irods/message/endtransaction_response.go
@@ -1,0 +1,31 @@
+package message
+
+import (
+	"fmt"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+)
+
+// IRODSMessageEndTransactionResponse stores end transaction response
+type IRODSMessageEndTransactionResponse struct {
+	// empty structure
+	Result int
+}
+
+// CheckError returns error if server returned an error
+func (msg *IRODSMessageEndTransactionResponse) CheckError() error {
+	if msg.Result < 0 {
+		return common.MakeIRODSError(common.ErrorCode(msg.Result))
+	}
+	return nil
+}
+
+// FromMessage returns struct from IRODSMessage
+func (msg *IRODSMessageEndTransactionResponse) FromMessage(msgIn *IRODSMessage) error {
+	if msgIn.Body == nil {
+		return fmt.Errorf("Cannot create a struct from an empty body")
+	}
+
+	msg.Result = int(msgIn.Body.IntInfo)
+	return nil
+}

--- a/irods/message/modcol_request.go
+++ b/irods/message/modcol_request.go
@@ -1,0 +1,67 @@
+package message
+
+import (
+	"encoding/xml"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+)
+
+// IRODSMessageModColRequest stores mod coll request
+type IRODSMessageModColRequest IRODSMessageMkcolRequest
+
+// NewIRODSMessageModColRequest creates a IRODSMessageModcolRequest message
+func NewIRODSMessageModColRequest(name string) *IRODSMessageModColRequest {
+	request := &IRODSMessageModColRequest{
+		Name:          name,
+		Flags:         0,
+		OperationType: 0,
+		KeyVals: IRODSMessageSSKeyVal{
+			Length: 0,
+		},
+	}
+
+	return request
+}
+
+// AddKeyVal adds a key-value pair
+func (msg *IRODSMessageModColRequest) AddKeyVal(key common.KeyWord, val string) {
+	msg.KeyVals.Add(string(key), val)
+}
+
+// GetBytes returns byte array
+func (msg *IRODSMessageModColRequest) GetBytes() ([]byte, error) {
+	xmlBytes, err := xml.Marshal(msg)
+	return xmlBytes, err
+}
+
+// FromBytes returns struct from bytes
+func (msg *IRODSMessageModColRequest) FromBytes(bytes []byte) error {
+	err := xml.Unmarshal(bytes, msg)
+	return err
+}
+
+// GetMessage builds a message
+func (msg *IRODSMessageModColRequest) GetMessage() (*IRODSMessage, error) {
+	bytes, err := msg.GetBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	msgBody := IRODSMessageBody{
+		Type:    RODS_MESSAGE_API_REQ_TYPE,
+		Message: bytes,
+		Error:   nil,
+		Bs:      nil,
+		IntInfo: int32(common.MOD_COLL_AN),
+	}
+
+	msgHeader, err := msgBody.BuildHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	return &IRODSMessage{
+		Header: msgHeader,
+		Body:   &msgBody,
+	}, nil
+}

--- a/irods/message/modcol_response.go
+++ b/irods/message/modcol_response.go
@@ -1,0 +1,31 @@
+package message
+
+import (
+	"fmt"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+)
+
+// IRODSMessageModColResponse stores alter metadata response
+type IRODSMessageModColResponse struct {
+	// empty structure
+	Result int
+}
+
+// CheckError returns error if server returned an error
+func (msg *IRODSMessageModColResponse) CheckError() error {
+	if msg.Result < 0 {
+		return common.MakeIRODSError(common.ErrorCode(msg.Result))
+	}
+	return nil
+}
+
+// FromMessage returns struct from IRODSMessage
+func (msg *IRODSMessageModColResponse) FromMessage(msgIn *IRODSMessage) error {
+	if msgIn.Body == nil {
+		return fmt.Errorf("Cannot create a struct from an empty body")
+	}
+
+	msg.Result = int(msgIn.Body.IntInfo)
+	return nil
+}


### PR DESCRIPTION
This has bitten me and and a couple of colleagues for a day or so.

1. Make 2 irods connections (e.g. two times session.AcquireConnection)
2. Make a change using the first connection (e.g. add metadata of an object)
3. List the metadata using the second connection.
4. Observe that you still see the situation before change in the first connection. However, when checking metadata with the first connection, or a new fresh connection, you see the updated situation.

One does not see this as long as only one connection from the pool is used.

We learned that

* irods starts a database transaction on every connection, queries will return the status at the beginning of that transaction
* most of irods update operations (adding a file, modifing metadata...) will do a database query in the back and commit the transaction
* some irods operations (bulk metadata changes) require an explicit commit by an endTransactionInp_PI api call

In this PR, I added the end transaction messages, and a Commit/Rollback function. Calling the Commit() function out of the blue is like doing nothing and still force a new database transaction to start and see the most recent changes in the database. This works however only for connections as rodsadmin.

For regular users, a dummy operation is enough. I added PoorMansCommit, but this should be cleaned up.
