### PR TITLE
Add admin messages

### DIFF
--- a/irods/connection/connection.go
+++ b/irods/connection/connection.go
@@ -26,7 +26,7 @@ type IRODSConnection struct {
 	connected         bool
 	socket            net.Conn
 	serverVersion     *types.IRODSVersion
-	generatedPassword string
+	GeneratedPassword string
 }
 
 // NewIRODSConnection create a IRODSConnection
@@ -395,10 +395,10 @@ func (conn *IRODSConnection) loginPAM() error {
 	}
 
 	// save irods generated password for possible future use
-	conn.generatedPassword = pamAuthResponse.GeneratedPassword
+	conn.GeneratedPassword = pamAuthResponse.GeneratedPassword
 
 	// retry native auth with generated password
-	return conn.loginNative(conn.generatedPassword)
+	return conn.loginNative(conn.GeneratedPassword)
 }
 
 // Disconnect disconnects

--- a/irods/connection/request_response.go
+++ b/irods/connection/request_response.go
@@ -1,0 +1,62 @@
+package connection
+
+import (
+	"fmt"
+
+	"github.com/cyverse/go-irodsclient/irods/message"
+)
+
+// A Request to send to irods.
+type Request interface {
+	GetMessage() (*message.IRODSMessage, error)
+}
+
+// A Response to retrieve from irods.
+type Response interface {
+	FromMessage(*message.IRODSMessage) error
+}
+
+// A CheckErrorResponse is a Response on which CheckError can be called.
+type CheckErrorResponse interface {
+	Response
+	CheckError() error
+}
+
+// Request sends a request and expects a response.
+func (conn *IRODSConnection) Request(request Request, response Response) error {
+	if conn == nil || !conn.IsConnected() {
+		return fmt.Errorf("connection is nil or disconnected")
+	}
+
+	requestMessage, err := request.GetMessage()
+	if err != nil {
+		return fmt.Errorf("Could not make a request message - %v", err)
+	}
+
+	err = conn.SendMessage(requestMessage)
+	if err != nil {
+		return fmt.Errorf("Could not send a request message - %v", err)
+	}
+
+	// Server responds with results
+	responseMessage, err := conn.ReadMessage()
+	if err != nil {
+		return fmt.Errorf("Could not receive a response message - %v", err)
+	}
+
+	err = response.FromMessage(responseMessage)
+	if err != nil {
+		return fmt.Errorf("Could not parse a response message - %v", err)
+	}
+
+	return nil
+}
+
+// RequestAndCheck sends a request and expects a CheckErrorResponse, on which the error is already checked.
+func (conn *IRODSConnection) RequestAndCheck(request Request, response CheckErrorResponse) error {
+	if err := conn.Request(request, response); err != nil {
+		return err
+	}
+
+	return response.CheckError()
+}

--- a/irods/fs/admin.go
+++ b/irods/fs/admin.go
@@ -1,0 +1,25 @@
+package fs
+
+import (
+	"github.com/thanhpk/randstr"
+
+	"github.com/cyverse/go-irodsclient/irods/connection"
+	"github.com/cyverse/go-irodsclient/irods/message"
+)
+
+// AddUser adds a user.
+func AddUser(conn *connection.IRODSConnection, username string) error {
+	// random scrambled password
+	scrambledPassword := randstr.Hex(30)
+
+	req := message.NewIRODSMessageUserAdminRequest("mkuser", username, scrambledPassword)
+
+	return conn.RequestAndCheck(req, &message.IRODSMessageUserAdminResponse{})
+}
+
+// AddChildToResc adds a child to a parent resource
+func AddChildToResc(conn *connection.IRODSConnection, parent, child, options string) error {
+	req := message.NewIRODSMessageAdminRequest("add", "childtoresc", parent, child, options)
+
+	return conn.RequestAndCheck(req, &message.IRODSMessageAdminResponse{})
+}

--- a/irods/message/admin_request.go
+++ b/irods/message/admin_request.go
@@ -1,0 +1,101 @@
+package message
+
+import (
+	"encoding/xml"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+)
+
+// IRODSMessageAdminRequest stores alter metadata request
+type IRODSMessageAdminRequest struct {
+	XMLName xml.Name `xml:"generalAdminInp_PI"`
+	Action  string   `xml:"arg0"` // add, modify, rm, ...
+	Target  string   `xml:"arg1"` // user, group, zone, resource, ...
+	Arg2    string   `xml:"arg2"`
+	Arg3    string   `xml:"arg3"`
+	Arg4    string   `xml:"arg4"`
+	Arg5    string   `xml:"arg5"`
+	Arg6    string   `xml:"arg6"`
+	Arg7    string   `xml:"arg7"`
+	Arg8    string   `xml:"arg8"` // unused
+	Arg9    string   `xml:"arg9"` // unused
+}
+
+func NewIRODSMessageAdminRequest(action, target string, args ...string) *IRODSMessageAdminRequest {
+	request := &IRODSMessageAdminRequest{
+		Action: action,
+		Target: target,
+	}
+
+	if len(args) > 0 {
+		request.Arg2 = args[0]
+	}
+
+	if len(args) > 1 {
+		request.Arg3 = args[1]
+	}
+
+	if len(args) > 2 {
+		request.Arg4 = args[2]
+	}
+
+	if len(args) > 3 {
+		request.Arg5 = args[3]
+	}
+
+	if len(args) > 4 {
+		request.Arg6 = args[4]
+	}
+
+	if len(args) > 5 {
+		request.Arg7 = args[5]
+	}
+
+	if len(args) > 6 {
+		request.Arg8 = args[6]
+	}
+
+	if len(args) > 7 {
+		request.Arg9 = args[7]
+	}
+
+	return request
+}
+
+// GetBytes returns byte array
+func (msg *IRODSMessageAdminRequest) GetBytes() ([]byte, error) {
+	xmlBytes, err := xml.Marshal(msg)
+	return xmlBytes, err
+}
+
+// FromBytes returns struct from bytes
+func (msg *IRODSMessageAdminRequest) FromBytes(bytes []byte) error {
+	err := xml.Unmarshal(bytes, msg)
+	return err
+}
+
+// GetMessage builds a message
+func (msg *IRODSMessageAdminRequest) GetMessage() (*IRODSMessage, error) {
+	bytes, err := msg.GetBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	msgBody := IRODSMessageBody{
+		Type:    RODS_MESSAGE_API_REQ_TYPE,
+		Message: bytes,
+		Error:   nil,
+		Bs:      nil,
+		IntInfo: int32(common.GENERAL_ADMIN_AN),
+	}
+
+	msgHeader, err := msgBody.BuildHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	return &IRODSMessage{
+		Header: msgHeader,
+		Body:   &msgBody,
+	}, nil
+}

--- a/irods/message/admin_response.go
+++ b/irods/message/admin_response.go
@@ -1,0 +1,31 @@
+package message
+
+import (
+	"fmt"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+)
+
+// IRODSMessageAdminResponse stores alter metadata response
+type IRODSMessageAdminResponse struct {
+	// empty structure
+	Result int
+}
+
+// CheckError returns error if server returned an error
+func (msg *IRODSMessageAdminResponse) CheckError() error {
+	if msg.Result < 0 {
+		return common.MakeIRODSError(common.ErrorCode(msg.Result))
+	}
+	return nil
+}
+
+// FromMessage returns struct from IRODSMessage
+func (msg *IRODSMessageAdminResponse) FromMessage(msgIn *IRODSMessage) error {
+	if msgIn.Body == nil {
+		return fmt.Errorf("Cannot create a struct from an empty body")
+	}
+
+	msg.Result = int(msgIn.Body.IntInfo)
+	return nil
+}

--- a/irods/message/useradmin_request.go
+++ b/irods/message/useradmin_request.go
@@ -1,0 +1,104 @@
+package message
+
+import (
+	"encoding/xml"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+)
+
+// IRODSMessageUserAdminRequest stores alter metadata request
+type IRODSMessageUserAdminRequest struct {
+	XMLName xml.Name `xml:"userAdminInp_PI"`
+	Action  string   `xml:"arg0"` // mkuser, mkgroup, modify
+	Arg1    string   `xml:"arg1"`
+	Arg2    string   `xml:"arg2"`
+	Arg3    string   `xml:"arg3"`
+	Arg4    string   `xml:"arg4"`
+	Arg5    string   `xml:"arg5"`
+	Arg6    string   `xml:"arg6"`
+	Arg7    string   `xml:"arg7"`
+	Arg8    string   `xml:"arg8"` // unused
+	Arg9    string   `xml:"arg9"` // unused
+}
+
+func NewIRODSMessageUserAdminRequest(action string, args ...string) *IRODSMessageUserAdminRequest {
+	request := &IRODSMessageUserAdminRequest{
+		Action: action,
+	}
+
+	if len(args) > 0 {
+		request.Arg1 = args[0]
+	}
+
+	if len(args) > 1 {
+		request.Arg2 = args[1]
+	}
+
+	if len(args) > 2 {
+		request.Arg3 = args[2]
+	}
+
+	if len(args) > 3 {
+		request.Arg4 = args[3]
+	}
+
+	if len(args) > 4 {
+		request.Arg5 = args[4]
+	}
+
+	if len(args) > 5 {
+		request.Arg6 = args[5]
+	}
+
+	if len(args) > 6 {
+		request.Arg7 = args[6]
+	}
+
+	if len(args) > 7 {
+		request.Arg8 = args[7]
+	}
+
+	if len(args) > 8 {
+		request.Arg9 = args[8]
+	}
+
+	return request
+}
+
+// GetBytes returns byte array
+func (msg *IRODSMessageUserAdminRequest) GetBytes() ([]byte, error) {
+	xmlBytes, err := xml.Marshal(msg)
+	return xmlBytes, err
+}
+
+// FromBytes returns struct from bytes
+func (msg *IRODSMessageUserAdminRequest) FromBytes(bytes []byte) error {
+	err := xml.Unmarshal(bytes, msg)
+	return err
+}
+
+// GetMessage builds a message
+func (msg *IRODSMessageUserAdminRequest) GetMessage() (*IRODSMessage, error) {
+	bytes, err := msg.GetBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	msgBody := IRODSMessageBody{
+		Type:    RODS_MESSAGE_API_REQ_TYPE,
+		Message: bytes,
+		Error:   nil,
+		Bs:      nil,
+		IntInfo: int32(common.USER_ADMIN_AN),
+	}
+
+	msgHeader, err := msgBody.BuildHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	return &IRODSMessage{
+		Header: msgHeader,
+		Body:   &msgBody,
+	}, nil
+}

--- a/irods/message/useradmin_response.go
+++ b/irods/message/useradmin_response.go
@@ -1,0 +1,31 @@
+package message
+
+import (
+	"fmt"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+)
+
+// IRODSMessageUserAdminResponse stores alter metadata response
+type IRODSMessageUserAdminResponse struct {
+	// empty structure
+	Result int
+}
+
+// CheckError returns error if server returned an error
+func (msg *IRODSMessageUserAdminResponse) CheckError() error {
+	if msg.Result < 0 {
+		return common.MakeIRODSError(common.ErrorCode(msg.Result))
+	}
+	return nil
+}
+
+// FromMessage returns struct from IRODSMessage
+func (msg *IRODSMessageUserAdminResponse) FromMessage(msgIn *IRODSMessage) error {
+	if msgIn.Body == nil {
+		return fmt.Errorf("Cannot create a struct from an empty body")
+	}
+
+	msg.Result = int(msgIn.Body.IntInfo)
+	return nil
+}

--- a/irods/util/scramble.go
+++ b/irods/util/scramble.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"crypto/md5"
+)
+
+const wheel = `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!"#$%&'()*+,-./`
+
+// Scramble implements the obfEncodeByKey irods cpp function.
+func Scramble(in, key string) string {
+	// Key buffer
+	keyBuf := make([]byte, 100)
+
+	for i := 0; i < len(key) && i < 100; i++ {
+		keyBuf[i] = byte(key[i])
+	}
+
+	buffer := make([]byte, 64)
+
+	hash := md5.Sum(keyBuf)
+	copy(buffer, hash[:])
+
+	// Hash of the hash
+	hash = md5.Sum(buffer[0:16])
+	copy(buffer[16:], hash[:])
+
+	// Hash of 2 hashes
+	hash = md5.Sum(buffer[0:32])
+	copy(buffer[32:], hash[:])
+
+	// Hash of 2 hashes
+	hash = md5.Sum(buffer[0:32])
+	copy(buffer[48:], hash[:])
+
+	var out = []byte{}
+
+	for p := 0; p < len(in); p++ {
+		k := int(buffer[p%61])
+
+		var found bool
+
+		for i := 0; i < len(wheel); i++ {
+			if in[p] == wheel[i] {
+				j := (i + k) % len(wheel)
+				out = append(out, wheel[j])
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			out = append(out, in[p])
+		}
+	}
+
+	return string(out)
+}


### PR DESCRIPTION
Add connection.Request() abstraction layer for handling send/receive of
messages. Add administration request/response messages. Already add two
admin functions - more will follow.

Signed-off-by: Peter Verraedt <peter@verraedt.be>