### PR TITLE
Add RawBind function

### DIFF
--- a/irods/connection/connection.go
+++ b/irods/connection/connection.go
@@ -618,3 +618,9 @@ func (conn *IRODSConnection) poorMansEndTransaction(dummyCol string, commit bool
 	err = response.CheckError()
 	return err
 }
+
+// RawBind binds an IRODSConnection to a raw net.Conn socket - to be used for e.g. a proxy server setup
+func (conn *IRODSConnection) RawBind(socket net.Conn) {
+	conn.connected = true
+	conn.socket = socket
+}

--- a/irods/message/startuppack.go
+++ b/irods/message/startuppack.go
@@ -88,3 +88,13 @@ func (msg *IRODSMessageStartupPack) GetMessage() (*IRODSMessage, error) {
 		Body:   &msgBody,
 	}, nil
 }
+
+// FromMessage returns struct from IRODSMessage
+func (msg *IRODSMessageStartupPack) FromMessage(msgIn *IRODSMessage) error {
+	if msgIn.Body == nil {
+		return fmt.Errorf("Cannot create a struct from an empty body")
+	}
+
+	err := msg.FromBytes(msgIn.Body.Message)
+	return err
+}


### PR DESCRIPTION
Add a function to bind an IRODSConnection to an existing socket, without
further handling of authentication. This can be used for an irods proxy
server to listen on a socket, parse the first message which is always the
IRODSMessageStartupPack, open a connection to a backend based on
information in this startup message, and forward the startup message and
further communication to this backend. The user and zone are sent in the
startup message - so different zones could be served at a single ip
address.

Signed-off-by: Peter Verraedt <peter@verraedt.be>