### PR TITLE
Fix empty SpecColl_PI in DataObjInp_PI

### DIFF
--- a/irods/message/data_object_request.go
+++ b/irods/message/data_object_request.go
@@ -4,16 +4,16 @@ import "encoding/xml"
 
 // IRODSMessageDataObjectRequest ...
 type IRODSMessageDataObjectRequest struct {
-	XMLName                  xml.Name                      `xml:"DataObjInp_PI"`
-	Path                     string                        `xml:"objPath"`
-	CreateMode               int                           `xml:"createMode"`
-	OpenFlags                int                           `xml:"openFlags"`
-	Offset                   int64                         `xml:"offset"`
-	Size                     int64                         `xml:"dataSize"`
-	Threads                  int                           `xml:"numThreads"`
-	OperationType            int                           `xml:"oprType"`
-	SpecialCollectionPointer IRODSMessageSpecialCollection `xml:"SpecColl_PI"`
-	KeyVals                  IRODSMessageSSKeyVal          `xml:"KeyValPair_PI"`
+	XMLName                  xml.Name                       `xml:"DataObjInp_PI"`
+	Path                     string                         `xml:"objPath"`
+	CreateMode               int                            `xml:"createMode"`
+	OpenFlags                int                            `xml:"openFlags"`
+	Offset                   int64                          `xml:"offset"`
+	Size                     int64                          `xml:"dataSize"`
+	Threads                  int                            `xml:"numThreads"`
+	OperationType            int                            `xml:"oprType"`
+	SpecialCollectionPointer *IRODSMessageSpecialCollection `xml:"SpecColl_PI"`
+	KeyVals                  IRODSMessageSSKeyVal           `xml:"KeyValPair_PI"`
 }
 
 type IRODSMessageSpecialCollection struct {

--- a/irods/message/get_data_object_stat_response.go
+++ b/irods/message/get_data_object_stat_response.go
@@ -10,17 +10,17 @@ import (
 
 // IRODSMessageGetDataObjectStatResponse stores file stat request
 type IRODSMessageGetDataObjectStatResponse struct {
-	XMLName                  xml.Name                      `xml:"RodsObjStat_PI"`
-	Size                     int64                         `xml:"objSize"`
-	Type                     int                           `xml:"objType"`
-	DataMode                 int                           `xml:"dataMode"`
-	DataID                   string                        `xml:"dataId"`
-	ChkSum                   string                        `xml:"chksum"`
-	Owner                    string                        `xml:"ownerName"`
-	Zone                     string                        `xml:"ownerZone"`
-	CreateTime               string                        `xml:"createTime"`
-	ModifyTime               string                        `xml:"modifyTime"`
-	SpecialCollectionPointer IRODSMessageSpecialCollection `xml:"*SpecColl_PI"`
+	XMLName                  xml.Name                       `xml:"RodsObjStat_PI"`
+	Size                     int64                          `xml:"objSize"`
+	Type                     int                            `xml:"objType"`
+	DataMode                 int                            `xml:"dataMode"`
+	DataID                   string                         `xml:"dataId"`
+	ChkSum                   string                         `xml:"chksum"`
+	Owner                    string                         `xml:"ownerName"`
+	Zone                     string                         `xml:"ownerZone"`
+	CreateTime               string                         `xml:"createTime"`
+	ModifyTime               string                         `xml:"modifyTime"`
+	SpecialCollectionPointer *IRODSMessageSpecialCollection `xml:"SpecColl_PI"`
 	// stores error return
 	Result int `xml:"-"`
 }


### PR DESCRIPTION
Make SpecialCollectionPointer a pointer to the
IRODSMessageSpecialCollection struct to reflect the behaviour of the C/python clients. In usual data object creation or modification requests, the SpecColl_PI is empty, but we were not sending a nilpointer but an empty xml struct. This caused that the corresponding dynamic peps would contain an empty objPath in its DATAOBJINP argument (probably because the objPath of the empty SpecColl_PI was overwriting the value in the main struct).