### PR TITLE
File checksum retrieve call

### DIFF
--- a/irods/fs/checksum.go
+++ b/irods/fs/checksum.go
@@ -1,0 +1,55 @@
+package fs
+
+import (
+	"github.com/cyverse/go-irodsclient/irods/common"
+	"github.com/cyverse/go-irodsclient/irods/connection"
+	"github.com/cyverse/go-irodsclient/irods/message"
+	"github.com/cyverse/go-irodsclient/irods/types"
+	"golang.org/x/xerrors"
+)
+
+func Checksum(conn *connection.IRODSConnection, irodsPath string) (string, error) {
+	if conn == nil || !conn.IsConnected() {
+		return "", xerrors.Errorf("connection is nil or disconnected")
+	}
+
+	metrics := conn.GetMetrics()
+	if metrics != nil {
+		metrics.IncreaseCounterForDataObjectOpen(1)
+	}
+
+	// lock the connection
+	conn.Lock()
+	defer conn.Unlock()
+
+	fileOpenMode := types.FileOpenMode("r")
+	resource := conn.GetAccount().DefaultResource
+	flag := fileOpenMode.GetFlag()
+	request := &message.ChecksumRequest{
+		Path:          irodsPath,
+		CreateMode:    0,
+		OpenFlags:     flag,
+		Offset:        0,
+		Size:          -1,
+		Threads:       0,
+		OperationType: 0,
+		KeyVals:       message.IRODSMessageSSKeyVal{},
+	}
+
+	if len(resource) > 0 {
+		request.KeyVals.Add(string(common.DEST_RESC_NAME_KW), resource)
+	}
+
+	response := message.ChecksumResponse{}
+
+	err := conn.RequestAndCheck(request, &response, nil)
+	if err != nil {
+		if types.GetIRODSErrorCode(err) == common.CAT_NO_ROWS_FOUND {
+			return "", types.NewFileNotFoundErrorf("could not find a data object")
+		}
+
+		return "", err
+	}
+
+	return response.Checksum, nil
+}

--- a/irods/message/checksum_request.go
+++ b/irods/message/checksum_request.go
@@ -1,0 +1,34 @@
+package message
+
+import (
+	"encoding/xml"
+
+	"github.com/cyverse/go-irodsclient/irods/common"
+)
+
+type ChecksumRequest IRODSMessageDataObjectRequest
+
+func (msg *ChecksumRequest) GetMessage() (*IRODSMessage, error) {
+	bytes, err := xml.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	msgBody := IRODSMessageBody{
+		Type:    RODS_MESSAGE_API_REQ_TYPE,
+		Message: bytes,
+		Error:   nil,
+		Bs:      nil,
+		IntInfo: int32(common.DATA_OBJ_CHKSUM_AN),
+	}
+
+	msgHeader, err := msgBody.BuildHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	return &IRODSMessage{
+		Header: msgHeader,
+		Body:   &msgBody,
+	}, nil
+}

--- a/irods/message/checksum_response.go
+++ b/irods/message/checksum_response.go
@@ -1,0 +1,32 @@
+package message
+
+import (
+	"encoding/xml"
+
+	"golang.org/x/xerrors"
+)
+
+type ChecksumResponse struct {
+	Checksum string
+}
+
+type STRI_PI struct {
+	MyStr string `xml:"myStr"`
+}
+
+func (c *ChecksumResponse) FromMessage(m *IRODSMessage) error {
+	if m == nil || m.Body == nil {
+		return xerrors.Errorf("response message has no body")
+	}
+	res := STRI_PI{}
+	err := xml.Unmarshal(m.Body.Message, &res)
+	c.Checksum = res.MyStr
+	return err
+}
+
+func (c *ChecksumResponse) CheckError() error {
+	if len(c.Checksum) == 0 {
+		return xerrors.Errorf("checksum not present in response message")
+	}
+	return nil
+}


### PR DESCRIPTION
Hi,
I am using this library in [rdm-integration](https://github.com/libis/rdm-integration) project, where among other things, I need to compare the content between the source and the destination files. I have noticed that there exists a way of retrieving the checksum from IRods, but this client did not implement it yet. Since I need the checksum for easy change detection, I have implemented the call. Please let me know if you want me to change something before merging.
Thanks!