### PR TITLE
Fix NewIRODSSessionConfig argument in get_ticket example

### DIFF
--- a/examples/get_ticket/get_ticket.go
+++ b/examples/get_ticket/get_ticket.go
@@ -47,7 +47,7 @@ func main() {
 	// Create a file system
 	appName := "get_ticket"
 	config := fs.NewFileSystemConfigWithDefault(appName)
-	sessConfig := session.NewIRODSSessionConfig(config.ApplicationName, config.ConnectionErrorTimeout, config.ConnectionInitNumber, config.ConnectionLifespan, config.OperationTimeout, config.ConnectionIdleTimeout, config.ConnectionMax, config.TCPBufferSize, config.StartNewTransaction)
+	sessConfig := session.NewIRODSSessionConfig(config.ApplicationName, config.ConnectionErrorTimeout, config.ConnectionInitNumber, config.ConnectionLifespan, config.OperationTimeout, config.ConnectionIdleTimeout, config.ConnectionMax, config.TcpBufferSize, config.StartNewTransaction)
 	sess, err := session.NewIRODSSession(account, sessConfig)
 	if err != nil {
 		logger.Error(err)


### PR DESCRIPTION
Looks like the field changed capitalization at some point. (I noticed after submitting, `IRODSSessionTCPBufferSizeDefault` uses `TCP`, so not sure which is current, that or `Tcp`)