### PR TITLE
Add support for the irods_authentication_file config property

### DIFF
--- a/utils/icommands/environment.go
+++ b/utils/icommands/environment.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	environmentDirDefault string = "~/.irods"
-	passwordFilename      string = ".irodsA"
-	environmentFilename   string = "irods_environment.json"
+	environmentDirDefault   string = "~/.irods"
+	passwordFilenameDefault string = ".irodsA"
+	environmentFilename     string = "irods_environment.json"
 )
 
 // ICommandsEnvironmentManager is a struct that manages icommands environment files
@@ -137,7 +137,11 @@ func (manager *ICommandsEnvironmentManager) GetSessionFilePath(processID int) st
 
 // GetPasswordFilePath returns password file (.irodsA) path
 func (manager *ICommandsEnvironmentManager) GetPasswordFilePath() string {
-	return filepath.Join(manager.HomeEnvironmentDirPath, passwordFilename)
+	if manager.Environment.AuthenticationFile != "" {
+		return manager.Environment.AuthenticationFile
+	}
+
+	return filepath.Join(manager.HomeEnvironmentDirPath, passwordFilenameDefault)
 }
 
 // Load loads from environment file
@@ -238,7 +242,7 @@ func (manager *ICommandsEnvironmentManager) SaveEnvironment() error {
 		return xerrors.Errorf("failed to write environment to file %s: %w", environmentFilePath, err)
 	}
 
-	passwordFilePath := filepath.Join(manager.HomeEnvironmentDirPath, passwordFilename)
+	passwordFilePath := manager.GetPasswordFilePath()
 	err = EncodePasswordFile(passwordFilePath, manager.Password, manager.UID)
 	if err != nil {
 		return xerrors.Errorf("failed to encode password file %s: %w", passwordFilePath, err)

--- a/utils/icommands/password_obfuscation.go
+++ b/utils/icommands/password_obfuscation.go
@@ -37,7 +37,7 @@ var (
 	}
 )
 
-// DecodePasswordFile decodes password string in .irodsA file
+// DecodePasswordFile decodes password string in an auth file (defaults to .irodsA)
 func DecodePasswordFile(path string, uid int) (string, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -47,9 +47,10 @@ func DecodePasswordFile(path string, uid int) (string, error) {
 	return DecodePasswordString(string(content), uid), nil
 }
 
-// EncodePasswordFile encodes password string and store in .irodsA file
+// EncodePasswordFile encodes password string and stores it in an auth file (defaults to .irodsA)
 func EncodePasswordFile(path string, s string, uid int) error {
 	content := EncodePasswordString(s, uid)
+
 	err := os.WriteFile(path, []byte(content), 0600)
 	if err != nil {
 		return xerrors.Errorf("failed to write file %s: %w", path, err)
@@ -57,7 +58,7 @@ func EncodePasswordFile(path string, s string, uid int) error {
 	return nil
 }
 
-// DecodePasswordString decodes password string in .irodsA file
+// DecodePasswordString decodes password string in an auth file (defaults to .irodsA)
 func DecodePasswordString(encodedPassword string, uid int) string {
 	s := []byte(encodedPassword)
 
@@ -122,7 +123,7 @@ func DecodePasswordString(encodedPassword string, uid int) string {
 	return string(decodedString)
 }
 
-// EncodePasswordString encodes password string to be stored in .irodsA file
+// EncodePasswordString encodes password string to be stored in an auth file (defaults to .irodsA)
 func EncodePasswordString(s string, uid int) string {
 	// mtime & 65535 needs to be within 20 seconds of the
 	// .irodsA file's mtime & 65535


### PR DESCRIPTION
Hello,

I'll hope you'll consider this PR which adds support for changing the password file name/location. We have several iRODS instances and typically have `~/.irods/` directories with several configurations in them, so need to change the password (`.irodsA`) file from its default name, to avoid clashes.

This adds support for loading a user-specified path for the iRODS password file, defined by the `irods_authentication_file` property in the iRODS environment file. The default behaviour of using a file named `.irodsA` within the environment directory remains unchanged.
