### PR TITLE
Allow to specify TLS hostname

### DIFF
--- a/irods/connection/connection.go
+++ b/irods/connection/connection.go
@@ -434,10 +434,16 @@ func (conn *IRODSConnection) sslStartup() error {
 		return xerrors.Errorf("Failed to load CA Certificates: %w", err)
 	}
 
+	serverName := conn.account.Host
+
+	if conn.account.ServerNameTLS != "" {
+		serverName = conn.account.ServerNameTLS
+	}
+
 	sslConf := &tls.Config{
 		RootCAs:            caCertPool,
-		ServerName:         conn.account.Host,
-		InsecureSkipVerify: true,
+		ServerName:         serverName,
+		InsecureSkipVerify: conn.account.SkipVerifyTLS,
 	}
 
 	// Create a side connection using the existing socket

--- a/irods/types/account.go
+++ b/irods/types/account.go
@@ -31,6 +31,8 @@ type IRODSAccount struct {
 	PamTTL                  int
 	PamToken                string
 	SSLConfiguration        *IRODSSSLConfig
+	ServerNameTLS           string // Optional TLS Server Name for SNI connection and TLS verification - defaults to Host
+	SkipVerifyTLS           bool   // Skip TLS verification
 }
 
 // CreateIRODSAccount creates IRODSAccount

--- a/irods/types/cs_negotiation.go
+++ b/irods/types/cs_negotiation.go
@@ -78,6 +78,17 @@ func PerformCSNegotiation(clientRequest CSNegotiationRequire, serverRequest CSNe
 		}
 	}
 
+	if clientRequest == CSNegotiationDontCare {
+		switch serverRequest {
+		case CSNegotiationRequireTCP:
+			return CSNegotiationUseTCP
+		case CSNegotiationRequireSSL:
+			return CSNegotiationUseSSL
+		default:
+			return CSNegotiationFailure
+		}
+	}
+
 	if clientRequest == serverRequest {
 		switch clientRequest {
 		case CSNegotiationRequireTCP:


### PR DESCRIPTION
Allow to overwrite the TLS hostname to be able to connect to irods servers whose certificate name is different from the connecting address.

Also make InsecureSkipVerify a boolean instead of never verifying.