### PR TITLE
do not truncate, but remove before upload to overwrite

### DIFF
--- a/examples/download/download.go
+++ b/examples/download/download.go
@@ -67,7 +67,7 @@ func main() {
 
 	logger.Infof("iRODS path: %q", result.IRODSPath)
 	logger.Infof("Local path: %q", result.LocalPath)
-	logger.Infof("Checksum: %s, iRODS: %q, Local: %q", result.CheckSumAlgorithm, hex.EncodeToString(result.IRODSCheckSum), hex.EncodeToString(result.LocalCheckSum))
+	logger.Infof("Checksum: iRODS: %s:%q, Local: %s:%q", result.IRODSCheckSumAlgorithm, hex.EncodeToString(result.IRODSCheckSum), result.LocalCheckSumAlgorithm, hex.EncodeToString(result.LocalCheckSum))
 	logger.Infof("Size: iRODS: %d, Local: %d", result.IRODSSize, result.LocalSize)
 
 	fsinfo, err := os.Stat(destPath)

--- a/examples/download_parallel/download_parallel.go
+++ b/examples/download_parallel/download_parallel.go
@@ -67,7 +67,7 @@ func main() {
 
 	logger.Infof("iRODS path: %q", result.IRODSPath)
 	logger.Infof("Local path: %q", result.LocalPath)
-	logger.Infof("Checksum: %s, iRODS: %q, Local: %q", result.CheckSumAlgorithm, hex.EncodeToString(result.IRODSCheckSum), hex.EncodeToString(result.LocalCheckSum))
+	logger.Infof("Checksum: iRODS: %s:%q, Local: %s:%q", result.IRODSCheckSumAlgorithm, hex.EncodeToString(result.IRODSCheckSum), result.LocalCheckSumAlgorithm, hex.EncodeToString(result.LocalCheckSum))
 	logger.Infof("Size: iRODS: %d, Local: %d", result.IRODSSize, result.LocalSize)
 
 	fsinfo, err := os.Stat(destPath)

--- a/examples/download_parallel_resumable/download_parallel_resumable.go
+++ b/examples/download_parallel_resumable/download_parallel_resumable.go
@@ -67,7 +67,7 @@ func main() {
 
 	logger.Infof("iRODS path: %q", result.IRODSPath)
 	logger.Infof("Local path: %q", result.LocalPath)
-	logger.Infof("Checksum: %s, iRODS: %q, Local: %q", result.CheckSumAlgorithm, hex.EncodeToString(result.IRODSCheckSum), hex.EncodeToString(result.LocalCheckSum))
+	logger.Infof("Checksum: iRODS: %s:%q, Local: %s:%q", result.IRODSCheckSumAlgorithm, hex.EncodeToString(result.IRODSCheckSum), result.LocalCheckSumAlgorithm, hex.EncodeToString(result.LocalCheckSum))
 	logger.Infof("Size: iRODS: %d, Local: %d", result.IRODSSize, result.LocalSize)
 
 	fsinfo, err := os.Stat(destPath)

--- a/examples/download_resumable/download_resumable.go
+++ b/examples/download_resumable/download_resumable.go
@@ -67,7 +67,7 @@ func main() {
 
 	logger.Infof("iRODS path: %q", result.IRODSPath)
 	logger.Infof("Local path: %q", result.LocalPath)
-	logger.Infof("Checksum: %s, iRODS: %q, Local: %q", result.CheckSumAlgorithm, hex.EncodeToString(result.IRODSCheckSum), hex.EncodeToString(result.LocalCheckSum))
+	logger.Infof("Checksum: iRODS: %s:%q, Local: %s:%q", result.IRODSCheckSumAlgorithm, hex.EncodeToString(result.IRODSCheckSum), result.LocalCheckSumAlgorithm, hex.EncodeToString(result.LocalCheckSum))
 	logger.Infof("Size: iRODS: %d, Local: %d", result.IRODSSize, result.LocalSize)
 
 	fsinfo, err := os.Stat(destPath)

--- a/examples/upload/upload.go
+++ b/examples/upload/upload.go
@@ -77,7 +77,7 @@ func main() {
 
 	logger.Infof("iRODS path: %q", result.IRODSPath)
 	logger.Infof("Local path: %q", result.LocalPath)
-	logger.Infof("Checksum: %s, iRODS: %q, Local: %q", result.CheckSumAlgorithm, hex.EncodeToString(result.IRODSCheckSum), hex.EncodeToString(result.LocalCheckSum))
+	logger.Infof("Checksum: iRODS: %s:%q, Local: %s:%q", result.IRODSCheckSumAlgorithm, hex.EncodeToString(result.IRODSCheckSum), result.LocalCheckSumAlgorithm, hex.EncodeToString(result.LocalCheckSum))
 	logger.Infof("Size: iRODS: %d, Local: %d", result.IRODSSize, result.LocalSize)
 
 	ttaken := time.Since(tstart)

--- a/examples/upload_parallel/upload_parallel.go
+++ b/examples/upload_parallel/upload_parallel.go
@@ -67,7 +67,7 @@ func main() {
 
 	logger.Infof("iRODS path: %q", result.IRODSPath)
 	logger.Infof("Local path: %q", result.LocalPath)
-	logger.Infof("Checksum: %s, iRODS: %q, Local: %q", result.CheckSumAlgorithm, hex.EncodeToString(result.IRODSCheckSum), hex.EncodeToString(result.LocalCheckSum))
+	logger.Infof("Checksum: iRODS: %s:%q, Local: %s:%q", result.IRODSCheckSumAlgorithm, hex.EncodeToString(result.IRODSCheckSum), result.LocalCheckSumAlgorithm, hex.EncodeToString(result.LocalCheckSum))
 	logger.Infof("Size: iRODS: %d, Local: %d", result.IRODSSize, result.LocalSize)
 
 	fsentry, err := filesystem.Stat(destPath)

--- a/irods/fs/data_object_bulk.go
+++ b/irods/fs/data_object_bulk.go
@@ -66,7 +66,8 @@ func UploadDataObjectFromBuffer(session *session.IRODSSession, buffer *bytes.Buf
 	}
 
 	// open a new file
-	handle, err := OpenDataObjectWithOperation(conn, irodsPath, resource, "w+", common.OPER_TYPE_NONE, keywords)
+	handle, err := CreateDataObject(conn, irodsPath, resource, "w+", true, keywords)
+	//handle, err := OpenDataObjectWithOperation(conn, irodsPath, resource, "w+", common.OPER_TYPE_NONE, keywords)
 	if err != nil {
 		return xerrors.Errorf("failed to open data object %q: %w", irodsPath, err)
 	}
@@ -138,7 +139,8 @@ func UploadDataObject(session *session.IRODSSession, localPath string, irodsPath
 	defer f.Close()
 
 	// open a new file
-	handle, err := OpenDataObjectWithOperation(conn, irodsPath, resource, "w+", common.OPER_TYPE_NONE, keywords)
+	handle, err := CreateDataObject(conn, irodsPath, resource, "w+", true, keywords)
+	//handle, err := OpenDataObjectWithOperation(conn, irodsPath, resource, "w+", common.OPER_TYPE_NONE, keywords)
 	if err != nil {
 		return xerrors.Errorf("failed to open data object %q: %w", irodsPath, err)
 	}

--- a/irods/types/file.go
+++ b/irods/types/file.go
@@ -61,6 +61,26 @@ func (mode FileOpenMode) GetFlag() int {
 	return flag
 }
 
+// Truncate returns if the mode needs truncating the file
+func (mode FileOpenMode) Truncate() bool {
+	switch mode {
+	case FileOpenModeReadOnly:
+		return false
+	case FileOpenModeReadWrite:
+		return false
+	case FileOpenModeWriteOnly:
+		return false
+	case FileOpenModeWriteTruncate:
+		return true
+	case FileOpenModeAppend:
+		return false
+	case FileOpenModeReadAppend:
+		return false
+	default:
+		return false
+	}
+}
+
 // SeekToEnd returns if the mode needs seeking to end
 func (mode FileOpenMode) SeekToEnd() bool {
 	_, seekToEnd := mode.GetFlagSeekToEnd()


### PR DESCRIPTION
- separate irods checksum alg and local checksum alg
- delete before upload instead of truncate, sometimes truncate can fail due to cache inconsistency