### PR TITLE
Add authentication steps to login

### DIFF
--- a/irods/connection/connection.go
+++ b/irods/connection/connection.go
@@ -606,6 +606,8 @@ func (conn *IRODSConnection) loginPAMWithPasswordPlugin() error {
 
 	plugin := NewPAMPasswordAuthPlugin(conn.isSSLSocket)
 	authContext := NewIRODSAuthContext()
+	authContext.Set("password", conn.account.Password)
+	authContext.Set(AUTH_TTL_KEY, "0")
 
 	return AuthenticateClient(conn, plugin, authContext)
 }


### PR DESCRIPTION
We've noticed that users aren't able to log in to our Yoda servers with gocommands v 0.12.0. It seems this would fix that issue.